### PR TITLE
fix: dev error

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "rehype-stringify": "^10.0.0",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.0",
+    "shiki": "^4.0.2",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
When starting the dev server, the following error was being thrown:

```
 ⨯ ./node_modules/rehype-pretty-code/dist/index.js:1:1
Module not found: Can't resolve 'shiki'

https://nextjs.org/docs/messages/module-not-found

Import trace for requested module:
./components/code.tsx
./app/(components)/example-code.tsx
./app/page.tsx
 ⨯ ./node_modules/rehype-pretty-code/dist/index.js:1:1
```

This commit fixes the issue