### PR TITLE
fix: `components` prop merging breaking partial overrides

### DIFF
--- a/components/ui/calendar-heatmap.tsx
+++ b/components/ui/calendar-heatmap.tsx
@@ -88,6 +88,7 @@ function CalendarHeatmap({
   datesPerVariant,
   weightedDates,
   className,
+  components,
   classNames,
   showOutsideDays = true,
   ...props
@@ -146,6 +147,7 @@ function CalendarHeatmap({
       components={{
         IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" />,
         IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" />,
+        ...components,
       }}
       {...props}
     />


### PR DESCRIPTION
Previously, passing a partial `components` object (e.g. only overriding `Head`) caused unintended breakage by overriding the entire internal components object, including default components like `IconLeft` and `IconRight`.

### Issue
Providing partial overrides like:
```tsx
components={{
  Head: () => <p>Dummy header</p>
}}
```
would remove other default internal components such as `IconLeft` and `IconRight`, leading to UI issues.

### Fix
- Merge default components with user-provided ones
- Preserve internal components like `IconLeft` and `IconRight` unless explicitly overridden
- Ensure safe partial overrides without breaking the calendar

### Result
Consumers can now override only what they need while the rest of the component continues to function as expected.