### PR TITLE
fix: modifiers merging to support safe extension

### DIFF
--- a/components/ui/calendar-heatmap.tsx
+++ b/components/ui/calendar-heatmap.tsx
@@ -89,6 +89,8 @@ function CalendarHeatmap({
   weightedDates,
   className,
   classNames,
+  modifiers: extendModifiers,
+  modifiersClassNames: extendModifierClassNames,
   showOutsideDays = true,
   ...props
 }: CalendarProps) {
@@ -105,8 +107,8 @@ function CalendarHeatmap({
 
   return (
     <DayPicker
-      modifiers={modifiers}
-      modifiersClassNames={modifiersClassNames}
+      modifiers={{ ...modifiers, ...extendModifiers }}
+      modifiersClassNames={{ ...modifiersClassNames, ...extendModifierClassNames }}
       showOutsideDays={showOutsideDays}
       className={cn("p-3", className)}
       classNames={{


### PR DESCRIPTION
Adds support for extending "modifiers" and "modifiersClassNames" without overriding existing values.

### Issue
Previously, providing custom "modifiers" or "modifiersClassNames" could override the defaults, leading to loss of built-in styling and behavior.

### Fix
- Merge "modifiers" with "extendModifiers"
- Merge "modifiersClassNames" with "extendModifierClassNames"
- Ensure default modifiers remain intact unless explicitly overridden

### Result
Consumers can now safely extend modifiers and their class names without breaking existing functionality or styles.